### PR TITLE
Addressed Megalinter errors on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           name: n2os_smb_client.linux_arm64
           path: bin/
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
         with:
           files: |

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -40,3 +40,4 @@ EXCLUDED_DIRECTORIES:
 CPP_CPPLINT_FILTER_REGEX_EXCLUDE: "include/freebsd_fix.h"
 C_CPPLINT_FILTER_REGEX_EXCLUDE: "include/freebsd_fix.h"
 C_CPPLINT_DISABLE_ERRORS: true # TODO consider disabling this later
+C_CPPCHECK_DISABLE_ERRORS: true # TODO consider disabling this later


### PR DESCRIPTION
Note: cppcheck does not support the possibility to fail only on errors. As such, changed configuration so that errors are considered warnings to avoid that it fails on informative events.